### PR TITLE
partial calls require .html suffix

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,7 @@
   </div>
 </div>
 </div>
-{{ partial "footer_scripts" . }}
+{{ partial "footer_scripts.html" . }}
 
 </body>
 </html>


### PR DESCRIPTION
make work with older hugo versions by specifying the suffix as per
https://discuss.gohugo.io/t/fixed-calling-partial-without-specifying-html-suffix/6028