### PR TITLE
add gitlab to social parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ These are the social network parameters for your overall site. They should be se
 | Field Name       | Required | Description                                                                                                      | Example              |
 |------------------|----------|------------------------------------------------------------------------------------------------------------------|----------------------|
 | `github`         | No       | GitHub username only.                                                                                            | "mattstratton"       |
+| `gitlab`         | No       | GitLab username only.                                                                                            | "mattstratton"       |
 | `facebook`       | No       | Name of the Facebook page (not the URL).                                                                         | "Arresteddevops"      |
 | `facebook_admin` | No       | This needs to be a page admin to get domain insights.                                                            | "500557137"          |
 | `twitter`        | No       | Twitter name without the `@` sign.                                                                               | "arresteddevops"     |

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -66,6 +66,7 @@ media_prefix = "https://media.blubrry.com/arresteddevops/content.blubrry.com/arr
 
   [params.social]
     github = "arresteddevops"
+    gitlab = "mattstratton"
     facebook = "Arresteddevops"
     facebook_admin = "500557137"  # This needs to be a page admin to get domain insights
     twitter = "arresteddevops"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -71,6 +71,11 @@
             <a class = "social-links" href="https://github.com/{{ .Site.Params.social.github }}"><i class="fa fa-github fa-2x"></i></a>
           </li>
         {{ end }}
+        {{ if (isset .Site.Params.social "gitlab" ) }}
+          <li>
+            <a class = "social-links" href="https://gitlab.com/{{ .Site.Params.social.gitlab }}"><i class="fa fa-gitlab fa-2x"></i></a>
+          </li>
+        {{ end }}
       </ul>
   </div>
   </div>


### PR DESCRIPTION
This PR simply adds [GitLab](https://gitlab.com) to the social icons at the top of the site.  It works exactly like the GitHub version of the icon and will only appear if the user defines a link to their GitLab profile in the site's `config.toml`.