### PR TITLE
Add direct download link for audio file

### DIFF
--- a/layouts/episode/single.html
+++ b/layouts/episode/single.html
@@ -49,6 +49,11 @@
           <audio src="{{ $.Site.Params.media_prefix }}{{ . }}" preload="auto"/>
         </div>
       </div>
+      <div class="row">
+        <div class="col-md-11 col-md-offset-1">
+          <a href="{{ $.Site.Params.media_prefix }}{{ . }}">Direct Download</a>
+        </div>
+      </div>
     {{- end -}}
   {{- with .Params.youtube -}}
     <div class = "row youtube_row">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -71,6 +71,11 @@
             <a class = "social-links" href="https://github.com/{{ .Site.Params.social.github }}"><i class="fa fa-github fa-2x"></i></a>
           </li>
         {{ end }}
+        {{ if (isset .Site.Params.social "gitlab" ) }}
+          <li>
+            <a class = "social-links" href="https://gitlab.com/{{ .Site.Params.social.gitlab }}"><i class="fa fa-gitlab fa-2x"></i></a>
+          </li>
+        {{ end }}
       </ul>
   </div>
   </div>


### PR DESCRIPTION
This PR adds a download link for the particular podcast audio file below the HTML player in the episode layout.  I'd imagine there might be a more elegant way to style it, but in a pinch it worked for my site.  