### PR TITLE
add site RSS feed icon to header social bar

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -76,6 +76,9 @@
             <a class = "social-links" href="https://gitlab.com/{{ .Site.Params.social.gitlab }}"><i class="fa fa-gitlab fa-2x"></i></a>
           </li>
         {{ end }}
+        <li>
+          <a class = "social-links" href="{{ .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}"><i class="fa fa-rss fa-2x"></i></a>
+        </li>
       </ul>
   </div>
   </div>


### PR DESCRIPTION
This PR adds a icon for the site's RSS feed in the header alongside the other social link icons.  I realize this is a bit redundant with the sidebar subscribe section, but I think it is convenient to have a simple icon to click on in the header too.  