### PR TITLE
Add a guests page

### DIFF
--- a/config.codekit3
+++ b/config.codekit3
@@ -4983,6 +4983,24 @@
 		"rFN": 0,
 		"uCM": 0
 		},
+	"\/exampleSite\/content\/guest\/_index.md": {
+		"cS": 0,
+		"eF": 1,
+		"eL": 1,
+		"eLB": 0,
+		"ema": 1,
+		"eSQ": 1,
+		"ft": 4096,
+		"oA": 1,
+		"oAP": "\/exampleSite\/content\/guest\/_index.html",
+		"oF": 0,
+		"oFM": 0,
+		"oS": 0,
+		"pHT": 0,
+		"pME": 1,
+		"rFN": 0,
+		"uCM": 0
+		},
 	"\/exampleSite\/content\/guest\/jsmith.md": {
 		"cS": 0,
 		"eF": 1,
@@ -5035,6 +5053,12 @@
 		"ft": 8192,
 		"oA": 2,
 		"oAP": "\/exampleSite\/data\/guests\/msmith.yml",
+		"oF": 0
+		},
+	"\/exampleSite\/data\/sponsors\/bluthcompany.yml": {
+		"ft": 8192,
+		"oA": 2,
+		"oAP": "\/exampleSite\/data\/sponsors\/bluthcompany.yml",
 		"oF": 0
 		},
 	"\/exampleSite\/public\/.gitkeep": {
@@ -7929,6 +7953,16 @@
 		"oT": 1,
 		"q": 100
 		},
+	"\/exampleSite\/static\/img\/sponsors\/bluthcompany.jpg": {
+		"ft": 16384,
+		"iS": 56682,
+		"oA": 0,
+		"oAP": "\/exampleSite\/static\/img\/sponsors\/bluthcompany.jpg",
+		"oF": 0,
+		"oIPL": 0,
+		"opt": 0,
+		"q": 100
+		},
 	"\/images\/screenshot-v01.png": {
 		"ft": 32768,
 		"iS": 545100,
@@ -7996,6 +8030,12 @@
 		"ft": 8192,
 		"oA": 2,
 		"oAP": "\/layouts\/episode\/single.html",
+		"oF": 0
+		},
+	"\/layouts\/guest\/list.html": {
+		"ft": 8192,
+		"oA": 2,
+		"oAP": "\/layouts\/guest\/list.html",
 		"oF": 0
 		},
 	"\/layouts\/guest\/single.html": {
@@ -8458,7 +8498,7 @@
 		"ma": 0,
 		"oA": 1,
 		"oAP": "\/static\/css\/custom.css",
-		"oF": 1,
+		"oF": 0,
 		"oS": 3,
 		"uL": 1
 		},

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,11 @@ themesdir = "../.."
     url = "contact"
 
 [[Menu.Main]]
+    name = "Guests"
+    identifier = "guests"
+    url = "guest"
+
+[[Menu.Main]]
     name = "Resources"
     identifier = "resources"
     url = "#!"

--- a/exampleSite/content/guest/_index.md
+++ b/exampleSite/content/guest/_index.md
@@ -1,8 +1,8 @@
 +++
 date = "2016-09-25T02:11:48-05:00"
 description = "guests of the show"
-title = "about"
+title = "Guests of HugoCast"
 
 +++
 
-Hello, I love you
+Want to be a guest on the HugoCast? Send us an email!

--- a/exampleSite/content/guest/_index.md
+++ b/exampleSite/content/guest/_index.md
@@ -1,0 +1,8 @@
++++
+date = "2016-09-25T02:11:48-05:00"
+description = "guests of the show"
+title = "about"
+
++++
+
+Hello, I love you

--- a/layouts/guest/list.html
+++ b/layouts/guest/list.html
@@ -31,7 +31,7 @@
           </div>
           <div class= "col-md-6">
             <h3>{{ .Title }}</h3>
-            {{ .Content | markdownify }}
+            <p>{{ .Content | markdownify }}</p>
             {{ with .Params.Website }}
               <a href = "{{ . }}"><i class="fa fa-home fa-2x"></i></a>
             {{ end }}

--- a/layouts/guest/list.html
+++ b/layouts/guest/list.html
@@ -21,16 +21,16 @@
           <div class="col-md-3">
             {{- if and (isset .Params "thumbnail") (ne .Params.thumbnail "") -}}
               {{- if (eq (slicestr .Params.thumbnail 0 4) "http") -}}
-                <img alt="{{ .Title }}" src="{{ .Params.thumbnail }}" class="img-fluid" width="250px">
+                <a href = "{{(printf "guest/%s" .File.BaseFileName) | absURL }}"><img alt="{{ .Title }}" src="{{ .Params.thumbnail }}" class="img-fluid" width="250px"></a>
                 {{- else -}}
-                <img alt="{{ .Title }}" src="{{ .Params.thumbnail | absURL}}" class="img-fluid" width="250px">
+                <a href = "{{(printf "guest/%s" .File.BaseFileName) | absURL }}"><img alt="{{ .Title }}" src="{{ .Params.thumbnail | absURL}}" class="img-fluid" width="250px"></a>
               {{- end -}}
               {{- else -}}
-              <img alt="{{ .Title }}" src="{{ "img/guest/default-guest.png" | absURL }}" class="img-fluid" width="250px"/>
+              <a href = "{{(printf "guest/%s" .File.BaseFileName) | absURL }}"><img alt="{{ .Title }}" src="{{ "img/guest/default-guest.png" | absURL }}" class="img-fluid" width="250px"/></a>
             {{- end -}}
           </div>
           <div class= "col-md-6">
-            <h3>{{ .Title }}</h3>
+            <h3><a href = "{{(printf "guest/%s" .File.BaseFileName) | absURL }}">{{ .Title }}</a></h3>
             <p>{{ .Content | markdownify }}</p>
             {{ with .Params.Website }}
               <a href = "{{ . }}"><i class="fa fa-home fa-2x"></i></a>

--- a/layouts/guest/list.html
+++ b/layouts/guest/list.html
@@ -1,0 +1,126 @@
+{{ define "main" }}
+
+<div class = "row">
+  <div class = "col-md-12">
+    <h1>Guests of {{ .Site.Title }}</h1>
+  </div>
+</div>
+{{ with .Content }}
+<div clas = "row">
+  <div class = "col">
+    {{ . }}
+  </div>
+</div>
+{{- end -}}
+<div class = "row">
+  <div class = "col">
+
+    {{ $paginator := .Paginate (where .Data.Pages "Type" "guest") }}
+    {{ range $paginator.Pages }}
+        <div class="row person_row">
+          <div class="col-md-3">
+            {{- if and (isset .Params "thumbnail") (ne .Params.thumbnail "") -}}
+              {{- if (eq (slicestr .Params.thumbnail 0 4) "http") -}}
+                <img alt="{{ .Title }}" src="{{ .Params.thumbnail }}" class="img-fluid" width="250px">
+                {{- else -}}
+                <img alt="{{ .Title }}" src="{{ .Params.thumbnail | absURL}}" class="img-fluid" width="250px">
+              {{- end -}}
+              {{- else -}}
+              <img alt="{{ .Title }}" src="{{ "img/guest/default-guest.png" | absURL }}" class="img-fluid" width="250px"/>
+            {{- end -}}
+          </div>
+          <div class= "col-md-6">
+            <h3>{{ .Title }}</h3>
+            {{ .Content | markdownify }}
+            {{ with .Params.Website }}
+              <a href = "{{ . }}"><i class="fa fa-home fa-2x"></i></a>
+            {{ end }}
+            {{ with .Params.Twitter }}
+              <a href = "https://twitter.com/{{ . }}"><i class="fa fa-twitter-square fa-2x"></i></a>
+            {{ end }}
+            {{ with .Params.GitHub}}
+              <a href = "https://github.com/{{ . }}"><i class="fa fa-github-square fa-2x"></i></a>
+            {{ end }}
+            {{ with .Params.LinkedIn }}
+              <a href = "https://www.linkedin.com/in/{{ . }}"><i class="fa fa-linkedin-square fa-2x"></i></a>
+            {{ end }}
+            {{ with .Params.Facebook }}
+              <a href = "https://www.facebook.com/{{ . }}"><i class="fa fa-facebook-square fa-2x"></i></a>
+            {{ end }}
+            {{ with .Params.Pinterest }}
+              <a href = "https://www.pinterest.com/{{ . }}"><i class="fa fa-pinterest-square fa-2x"></i></a>
+            {{ end }}
+            {{ with .Params.Instagram }}
+              <a href = "https://www.instagram.com/{{ . }}"><i class="fa fa-instagram fa-2x"></i></a>
+            {{ end }}
+            {{ with .Params.YouTube }}
+              <a href = "https://www.youtube.com/{{ . }}"><i class="fa fa-youtube-square fa-2x"></i></a>
+            {{ end }}
+        </div>
+      </div>
+  {{ end }}
+  </div>
+</div>
+{{ if gt $paginator.TotalPages 1 }}
+<div class = "row">
+<div class = "col">
+
+
+<nav class="pagination justify-content-center">
+
+{{ $pag := $.Paginator }}
+{{ $window := $.Site.Params.paginateWindow | default 1 }}
+{{ if gt $pag.TotalPages 1 }}
+  {{ $total := $pag.TotalPages }}
+  {{ $size := add 5 (add $window $window) }}
+  {{ $cur := $pag.PageNumber }}
+  {{ if gt $total $size }}
+    {{ if lt $cur (sub $size (add $window 1)) }}
+      {{ $.Scratch.Set "show" (seq 1 (sub $size 2)) }}
+    {{ else if lt (sub $total $cur) (sub $size (add $window 2)) }}
+      {{ $.Scratch.Set "show" (seq (add (sub $total $size) 3) $total) }}
+    {{ else }}
+      {{ $.Scratch.Set "show" (seq (sub $cur $window) (add $cur $window)) }}
+    {{ end }}
+    {{ $.Scratch.Add "show" 1 }}
+    {{ $.Scratch.Add "show" $total }}
+  {{ else }}
+    {{ $.Scratch.Set "show" (seq 1 $total) }}
+  {{ end }}
+
+<ul class="pagination pagination-lg">
+{{- with $paginator.First -}}
+  {{- $url := trim (string .URL) "/" | absURL -}}
+  <li class="page-item">
+      <a href="{{ $url }}" aria-label="First" class="page-link"><span aria-hidden="true">&laquo;&laquo;</span></a>
+  </li>
+{{- end -}}
+<li class="{{ if not $paginator.HasPrev }}disabled {{ end }}page-item">
+    <a href="{{ if $paginator.HasPrev }}{{ $paginator.Prev.URL }}{{ end }}" aria-label="Previous" class="page-link"><span aria-hidden="true">&laquo;</span></a>
+</li>
+
+  {{ range $pag.Pagers }}
+    {{ $cur := .PageNumber }}
+    {{- $url := trim (string .URL) "/" | absURL -}}
+    {{ if in ($.Scratch.Get "show") $cur }}
+      <li class = "{{ if eq . $pag }}active{{ end }} page-item"><a href="{{ .URL }}" class="page-link hidden-md-down">{{ .PageNumber }}</a></li>
+    {{ else if in (slice 2 (sub $total 1)) $cur }}
+      <li class="disabled page-item"><a name="" class="page-link hidden-md-down">&hellip;</a></li>
+    {{ end }}
+  {{ end }}
+  {{- with $paginator.Last -}}
+  {{- $url := trim (string .URL) "/" | absURL -}}
+  <li class="page-item">
+      <a href="{{ $url }}" aria-label="Last" class="page-link"><span aria-hidden="true">&raquo;&raquo;</span></a>
+  </li>
+{{- end -}}
+</ul>
+{{ end }}
+</nav>
+</div>
+</div>
+{{ end }}
+
+
+
+{{ end }}

--- a/layouts/guest/single.html
+++ b/layouts/guest/single.html
@@ -10,7 +10,15 @@
   <div class="col-lg-8">
     <div class="row">
       <div class="col-md-3">
-        <img src="{{ .Params.thumbnail | absURL }}" class="img-fluid episode_image"/>
+      {{- if and (isset .Params "thumbnail") (ne .Params.thumbnail "") -}}
+        {{- if (eq (slicestr .Params.thumbnail 0 4) "http") -}}
+          <img alt="{{ .Title }}" src="{{ .Params.thumbnail }}" class="img-fluid episode_image" width="250px">
+          {{- else -}}
+          <img alt="{{ .Title }}" src="{{ .Params.thumbnail | absURL}}" class="img-fluid episode_image" width="250px">
+        {{- end -}}
+        {{- else -}}
+        <img alt="{{ .Title }}" src="{{ "img/guest/default-guest.png" | absURL }}" class="img-fluid episode_image" width="250px"/>
+      {{- end -}}
       </div>
       <div class="col-md-8">
         <div class = "row">


### PR DESCRIPTION
This creates the page for all guests. It is available under the `/guest` URL (of course, you can set permalinks in your settings to make this different). You can also mess around with `_index.md` to make an alias I suppose.

Fixes #121 