### PR TITLE
don't fail in case of .Data.Pages type:episode absence

### DIFF
--- a/layouts/partials/row.html
+++ b/layouts/partials/row.html
@@ -109,6 +109,7 @@
 
 <section class="episode-list">
 <!-- rest of episodes -->
+{{- if (where .Data.Pages "Type" "episode") -}}
 {{- $paginator := .Paginate (after 1 (where .Data.Pages "Type" "episode")) 5 -}}
 {{- $list := (where .Data.Pages "Type" "episode") -}}
 {{- $len := (len $list) -}}
@@ -255,5 +256,6 @@
 </div>
 {{- end -}}
 </div>
+{{- end -}}
 </div>
 </div> <!-- end section -->


### PR DESCRIPTION
Fix #182.
I guess it's OK to fail in case no menus defined, but failure to generate empty boilerplate in case no episodes present yet is not OK, this PR fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mattstratton/castanet/183)
<!-- Reviewable:end -->
