### PR TITLE
Bug Fixes  & Improved Pagination to Grid and Row Layouts

### DIFF
--- a/layouts/partials/grid.html
+++ b/layouts/partials/grid.html
@@ -59,16 +59,27 @@
   {{ end }}
 
 <ul class="pagination pagination-lg">
-{{- with $paginator.First -}}
-  {{- $url := trim (string .URL) "/" | absURL -}}
-  <li class="page-item">
-      <a href="{{ $url }}" aria-label="First" class="page-link"><span aria-hidden="true">&laquo;&laquo;</span></a>
-  </li>
-{{- end -}}
-<li class="{{ if not $paginator.HasPrev }}disabled {{ end }}page-item">
-    <a href="{{ if $paginator.HasPrev }}{{ $paginator.Prev.URL }}{{ end }}" aria-label="Previous" class="page-link"><span aria-hidden="true">&laquo;</span></a>
-</li>
+	<!-- first page button -->
+  {{if $paginator.HasPrev }}
+    {{ if gt $paginator.PageNumber 2 }}
+        {{- with $paginator.First -}}
+        {{- $url := trim (string .URL) "/" | absURL -}}
+            <li class="page-item">
+            <a href="{{ $url }}" aria-label="First" class="page-link"><span aria-hidden="true">&laquo;&laquo;</span></a>
+            </li>
+        {{- end -}}
+    {{ end }}
+  {{ end }}
 
+
+  <!-- prev page button -->
+  {{- with $paginator.HasPrev -}}
+    	<li class="page-item">
+    		<a href="{{ $paginator.Prev.URL }}" class="page-link"> &laquo; </a>
+    	</li>
+  {{ end }}
+  
+  <!-- page # buttons -->
   {{ range $pag.Pagers }}
     {{ $cur := .PageNumber }}
     {{- $url := trim (string .URL) "/" | absURL -}}
@@ -78,12 +89,24 @@
       <li class="disabled page-item"><a name="" class="page-link hidden-md-down">&hellip;</a></li>
     {{ end }}
   {{ end }}
-  {{- with $paginator.Last -}}
-  {{- $url := trim (string .URL) "/" | absURL -}}
+  
+  <!-- next page button -->
+  {{- with $paginator.HasNext -}}
   <li class="page-item">
-      <a href="{{ $url }}" aria-label="Last" class="page-link"><span aria-hidden="true">&raquo;&raquo;</span></a>
+    <a href="{{ $paginator.Next.URL }}" class="page-link"> &raquo; </a>
   </li>
-{{- end -}}
+  {{ end }}
+  
+  <!-- last page button -->
+  {{ if lt $paginator.PageNumber (sub $paginator.TotalPages 1) }}
+    {{- with $paginator.Last -}}
+        {{- $url := trim (string .URL) "/" | absURL -}}
+            <li class="page-item">
+                <a href="{{ $url }}" aria-label="Last" class="page-link"><span aria-hidden="true">&raquo;&raquo;</span></a>
+            </li>
+    {{- end -}}
+  {{ end }}
+  
 </ul>
 {{ end }}
 </nav>

--- a/layouts/partials/row.html
+++ b/layouts/partials/row.html
@@ -224,16 +224,27 @@
   {{ end }}
 
 <ul class="pagination pagination-lg">
-{{- with $paginator.First -}}
-  {{- $url := trim (string .URL) "/" | absURL -}}
-  <li class="page-item">
-      <a href="{{ $url }}" aria-label="First" class="page-link"><span aria-hidden="true">&laquo;&laquo;</span></a>
-  </li>
-{{- end -}}
-<li class="{{ if not $paginator.HasPrev }}disabled {{ end }}page-item">
-    <a href="{{ if $paginator.HasPrev }}{{ $paginator.Prev.URL }}{{ end }}" aria-label="Previous" class="page-link"><span aria-hidden="true">&laquo;</span></a>
-</li>
+	<!-- first page button -->
+  {{if $paginator.HasPrev }}
+    {{ if gt $paginator.PageNumber 2 }}
+        {{- with $paginator.First -}}
+        {{- $url := trim (string .URL) "/" | absURL -}}
+            <li class="page-item">
+            <a href="{{ $url }}" aria-label="First" class="page-link"><span aria-hidden="true">&laquo;&laquo;</span></a>
+            </li>
+        {{- end -}}
+    {{ end }}
+  {{ end }}
 
+
+  <!-- prev page button -->
+  {{- with $paginator.HasPrev -}}
+    	<li class="page-item">
+    		<a href="{{ $paginator.Prev.URL }}" class="page-link"> &laquo; </a>
+    	</li>
+  {{ end }}
+  
+  <!-- page # buttons -->
   {{ range $pag.Pagers }}
     {{ $cur := .PageNumber }}
     {{- $url := trim (string .URL) "/" | absURL -}}
@@ -243,12 +254,23 @@
       <li class="disabled page-item"><a name="" class="page-link hidden-md-down">&hellip;</a></li>
     {{ end }}
   {{ end }}
-  {{- with $paginator.Last -}}
-  {{- $url := trim (string .URL) "/" | absURL -}}
+  
+  <!-- next page button -->
+  {{- with $paginator.HasNext -}}
   <li class="page-item">
-      <a href="{{ $url }}" aria-label="Last" class="page-link"><span aria-hidden="true">&raquo;&raquo;</span></a>
+    <a href="{{ $paginator.Next.URL }}" class="page-link"> &raquo; </a>
   </li>
-{{- end -}}
+  {{ end }}
+  
+  <!-- last page button -->
+  {{ if lt $paginator.PageNumber (sub $paginator.TotalPages 1) }}
+    {{- with $paginator.Last -}}
+        {{- $url := trim (string .URL) "/" | absURL -}}
+            <li class="page-item">
+                <a href="{{ $url }}" aria-label="Last" class="page-link"><span aria-hidden="true">&raquo;&raquo;</span></a>
+            </li>
+    {{- end -}}
+  {{ end }}
 </ul>
 {{ end }}
 </nav>


### PR DESCRIPTION
* Fixed a bug where no next page button was visible at all - primarily a problem on mobile where the page number buttons were missing.
* First and last page buttons only appear where current page is > 2 or > total pages - 2.
* Next and Previous page buttons only appear when there is an actual next or previous page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mattstratton/castanet/201)
<!-- Reviewable:end -->
