### PR TITLE
Update hugo version on Netlify to 0.55.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,10 +13,10 @@
   command = "bin/netlify.sh"
 
   [context.production.environment]
-     HUGO_VERSION = "0.36.1"
+     HUGO_VERSION = "0.55.6"
 
   [context.deploy-preview.environment]
-    HUGO_VERSION = "0.36.1"
+    HUGO_VERSION = "0.55.6"
 
   [context.branch-deploy.environment]
-    HUGO_VERSION = "0.36.1"
+    HUGO_VERSION = "0.55.6"


### PR DESCRIPTION
this updates the version that Netlify uses for the build test to `0.55.1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mattstratton/castanet/215)
<!-- Reviewable:end -->
