### PR TITLE
Extend bug fix #267 for hosts bio not showing to cover other pages

### DIFF
--- a/layouts/guest/single.html
+++ b/layouts/guest/single.html
@@ -23,7 +23,7 @@
       <div class="col-md-8">
         <div class = "row">
           <div class="col">
-            {{ .Content | markdownify }}
+            {{ .Content }}
           </div>
         </div>
         <div class = "row">

--- a/layouts/host/single.html
+++ b/layouts/host/single.html
@@ -23,7 +23,7 @@
       <div class="col-md-8">
         <div class = "row">
           <div class="col">
-            {{ .Content | markdownify }}
+            {{ .Content }}
           </div>
         </div>
         <div class = "row">


### PR DESCRIPTION
Extend bug fix #267 for hosts bio not showing to also the single pages for guests and hosts, which have the same issue.