### PR TITLE
Remove hard-coding of paginate value for sites with row layout

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -11,6 +11,7 @@ You will need to add a handful of configuration items to your `config.toml` file
 ### Top-level items
 
 - `googleAnalytics` - the Google Analytics tracking ID. We use the async method. Example: `"UA-123-45"`
+- `paginate` - The number of episodes to show per-page on the homepage (note, this also controls pagination for Guest and Host list pages). If this is not set, the default is 10.
 
 ### General Parameters
 

--- a/layouts/partials/row.html
+++ b/layouts/partials/row.html
@@ -112,7 +112,7 @@
 <section class="episode-list">
 <!-- rest of episodes -->
 {{- if (where site.RegularPages "Type" "in" site.Params.mainSections) -}}
-{{- $paginator := .Paginate (after 1 (where site.RegularPages "Type" "in" site.Params.mainSections)) 5 -}}
+{{- $paginator := .Paginate (after 1 (where site.RegularPages "Type" "in" site.Params.mainSections)) }}
 {{- $list := (where site.RegularPages "Type" "in" site.Params.mainSections) -}}
 {{- $len := (len $list) -}}
 <div class="row main_container">


### PR DESCRIPTION
For sites using row layout, remove hard-coding of pagination (at 5 posts) so the site-level `paginate` value defined in `config.toml` is used instead (like as is already the case for sites using grid layout).

Fixes #277