### PR TITLE
update Open Graph date format

### DIFF
--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -1,8 +1,9 @@
 <meta property="og:title" content="{{ title .Title }}" />
 <meta name="twitter:title" content="{{ .Title }}"/>
 <meta itemprop="name" content="{{ .Title }}">
-<meta property="article:modified_time" content="{{ .Date }}" />
-
+<meta property="article:published_time" content="{{ dateFormat "2006-01-02T15:04:05Z07:00" .Date }}" />
+<meta property="article:modified_time" content="{{ dateFormat "2006-01-02T15:04:05Z07:00" .Lastmod }}" />
+<meta property="og:updated_time" content="{{ dateFormat "2006-01-02T15:04:05Z07:00" .Lastmod }}" />
 
 {{- with .Site.Params.title -}}<meta property="og:site_name" content="{{ . }}" />{{- end -}}
 {{- with .Params.locale -}}<meta property="og:locale" content="{{ . }}" />{{- end -}}


### PR DESCRIPTION
The format of Open Graph dates today (i.e. “2020-08-05 10:06:15 -0500 -0500” from latest ADO episode) is not valid.

Adding a formatter as well as adding both article:publish_date and og:updated_time. Also, using .Lastmod for the updates/modifies instead of .Date.

Signed-off-by: Darin Pope <darin@planetpope.com>