### PR TITLE
Upcoming episodes should be sorted from soonest to furthest away

### DIFF
--- a/layouts/partials/grid-upcoming.html
+++ b/layouts/partials/grid-upcoming.html
@@ -8,7 +8,7 @@
 
     {{ $paginator := .Paginate (where ( where site.RegularPages "Type" "in" site.Params.mainSections) ".Params.upcoming" "==" true ) }}
 
-        {{ range $paginator.Pages }}
+        {{ range $paginator.Pages.ByDate }}
         {{ $.Scratch.Set "episode" .File.BaseFileName }}
           <div class="col-md-4 grid_episode_col">
             <div class="episode-image-homepage">

--- a/layouts/partials/row-upcoming.html
+++ b/layouts/partials/row-upcoming.html
@@ -14,7 +14,7 @@
 {{- else -}}
   <div class="col-md-8">
 {{- end -}}
-    {{- range $paginator.Pages -}}
+    {{- range $paginator.Pages.ByDate -}}
     {{- with .Params.truncate -}}
       {{- $.Scratch.Set "truncate" . }}
     {{- else -}}


### PR DESCRIPTION
By default, the upcoming episodes page is reverse sorted (i.e. dates which are further away displayed first). As a user, I would expect these to be chronological.

I believe these changes would make this work appropriately (as shown at www.cloudwithchris.com/upcoming), but I wasn't 100% on whether the pagination would have an impact on how this works (i.e. if we had > 1 page, would this show some strange sorting behaviour)?