### PR TITLE
Fixing RSS feed publishing bug

### DIFF
--- a/layouts/section/episode.rss.xml
+++ b/layouts/section/episode.rss.xml
@@ -64,7 +64,7 @@
               <title>{{ title .Title }}</title>
             {{ end }}
           {{ else }}
-            <h1>{{ title .Title }}</h1>
+            <title>{{ title .Title }}</title>
           {{ end }}
           <link>{{ .Permalink }}</link>
           <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }} </pubDate>


### PR DESCRIPTION
@mattstratton  - Looks like there was a bug in my recent changes, where there was a h1 tag instead of a title tag in the episode RSS feed. I've just noticed on my own website it looks like this has caused some issues with Apple Podcasts and Spotify.

Not sure of an elegant way to check for this as part of the build/PR step and validate that it is an appropriate RSS feed before commiting to master/main longer term, aside from automating a request to an external validator? This should solve the immediate issue.