### PR TITLE
Fixes Instagram icon

### DIFF
--- a/layouts/guest/list.html
+++ b/layouts/guest/list.html
@@ -61,7 +61,7 @@
               {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-pinterest-square fa-2x" "prefix" "https://www.pinterest.com/" "text" "") }}
             {{ end }}
             {{ with .Params.Instagram }}
-              {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-instagram-square fa-2x" "prefix" "https://www.instagram.com/" "text" "") }}
+              {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-instagram fa-2x" "prefix" "https://www.instagram.com/" "text" "") }}
             {{ end }}
             {{ with .Params.YouTube }}
               {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-youtube-square fa-2x" "prefix" "https://www.youtube.com/" "text" "") }}

--- a/layouts/guest/single.html
+++ b/layouts/guest/single.html
@@ -50,7 +50,7 @@
               {{ partial "social-link.html" (dict "context" .Params.Pinterest "aclass" "" "iclass" "fab fa-pinterest-square fa-2x" "prefix" "https://www.pinterest.com/" "text" "") }}
             {{ end }}
             {{ if .Params.Instagram }}
-              {{ partial "social-link.html" (dict "context" .Params.Instagram "aclass" "" "iclass" "fab fa-instagram-square fa-2x" "prefix" "https://www.instagram.com/" "text" "") }}
+              {{ partial "social-link.html" (dict "context" .Params.Instagram "aclass" "" "iclass" "fab fa-instagram fa-2x" "prefix" "https://www.instagram.com/" "text" "") }}
             {{ end }}
             {{ if .Params.YouTube }}
               {{ partial "social-link.html" (dict "context" .Params.YouTube "aclass" "" "iclass" "fab fa-youtube-square fa-2x" "prefix" "https://www.youtube.com/" "text" "") }}

--- a/layouts/host/single.html
+++ b/layouts/host/single.html
@@ -49,7 +49,7 @@
               {{ partial "social-link.html" (dict "context" .Params.Pinterest "iclass" "fab fa-pinterest-square fa-2x" "prefix" "https://www.pinterest.com/" "text" "") }}
             {{ end }}
             {{ if .Params.Instagram }}
-              {{ partial "social-link.html" (dict "context" .Params.Instagram "iclass" "fab fa-instagram-square fa-2x" "prefix" "https://www.instagram.com/" "text" "") }}
+              {{ partial "social-link.html" (dict "context" .Params.Instagram "iclass" "fab fa-instagram fa-2x" "prefix" "https://www.instagram.com/" "text" "") }}
             {{ end }}
             {{ if .Params.YouTube }}
               {{ partial "social-link.html" (dict "context" .Params.YouTube "iclass" "fab fa-youtube-square fa-2x" "prefix" "https://www.youtube.com/" "text" "") }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -54,7 +54,7 @@
         {{ end }}
         {{ if (isset .Site.Params.social "instagram" ) }}
           <li>
-            {{ partial "social-link.html" (dict "context" $.Site.Params.social.instagram "aclass" "social-links" "iclass" "fab fa-instagram-square fa-2x" "prefix" "https://www.instagram.com/" "text" "") }}
+            {{ partial "social-link.html" (dict "context" $.Site.Params.social.instagram "aclass" "social-links" "iclass" "fab fa-instagram fa-2x" "prefix" "https://www.instagram.com/" "text" "") }}
           </li>
         {{ end }}
         {{ if (isset .Site.Params.social "linkedin" ) }}

--- a/layouts/partials/hosts.html
+++ b/layouts/partials/hosts.html
@@ -42,7 +42,7 @@
                 {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-pinterest-square fa-2x" "prefix" "https://www.pinterest.com/") }}
               {{ end }}
               {{ with .Params.Instagram }}
-                {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-instagram-square fa-2x" "prefix" "https://www.instagram.com/") }}
+                {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-instagram fa-2x" "prefix" "https://www.instagram.com/") }}
               {{ end }}
               {{ with .Params.YouTube }}
                 {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-youtube-square fa-2x" "prefix" "https://www.youtube.com/") }}


### PR DESCRIPTION
I noticed that the instagram icon doesn't show up.
Changing `fa-instagram-square` to `fa-instagram` fixed the issue.