### PR TITLE
Fix hugo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ An example site can be found at http://sample-castanet.netlify.com/
 Download the latest version (zip file, not source code) from the [Releases](https://github.com/mattstratton/castanet/releases) page.
 
 
-For more information read the official [setup guide](//gohugo.io/overview/installing/) of Hugo.
+For more information read the official [setup guide](//gohugo.io/installation/) of Hugo.
 
 
 ## Getting started


### PR DESCRIPTION
The link to the installation docs is broken. So I found what I think you need to link to and updated it.