### PR TITLE
Address the deprecation notice enforced in Hugo v0.133.1

### DIFF
--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -3,7 +3,7 @@
   to be used together. There may be situations where a organization support both tag methods simultaneously.
 ------------->
 <!-- Check for the Global GoogleAnalytics variable to use the Hugo internal google_analytics template -->
-{{ if .Site.GoogleAnalytics }} {{ template "_internal/google_analytics.html" . }} {{ end }}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }} {{ template "_internal/google_analytics.html" . }} {{ end }}
 <!-- Check for googleAnalytics_UA param to use the google-analytics-ua partial -->
 {{ if .Site.Params.googleAnalytics_UA }} {{ partial "google-analytics-ua.html" . }} {{ end }}
 


### PR DESCRIPTION
Error message was:
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.