### PR TITLE
Remove `{{ hugo.Generator }}` template from meta.html partial.

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -9,4 +9,3 @@
   {{ if .Site.Params.Description }}<meta name="description" content="{{ .Site.Params.Description }}">
   {{ end }}
 {{ end }}
-{{ hugo.Generator }}


### PR DESCRIPTION
The `{{ hugo.Generator }}` is unnecessary since hugo will inject the generator tag to the <head> section without it.

However, the presence of `{{ hugo.Generator }}` will prevent the `disableHugoGeneratorInject` option in config.toml from taking effect.

See: https://gohugo.io/getting-started/configuration/#disablehugogeneratorinject