### PR TITLE
Add initial documentation folder with installation, configuration, usage, and migration guides

### DIFF
--- a/docs/creating-episodes-hosts-guests.md
+++ b/docs/creating-episodes-hosts-guests.md
@@ -35,15 +35,21 @@ upcoming = false
 
 ## Hosts
 
-Hosts are defined in your config under `[params.authors]`:
+Hosts are stored in `content/host/`. To create a new host:
+
+```sh
+hugo new host/your-hostname.md
+```
+
+A typical host front matter:
 
 ```toml
-[params.authors]
-  [params.authors.Matt]
-    name = "Matt Stratton"
-    pronouns = "he/him"
-    thumbnail = "img/hosts/matt.png"
-    bio = "Matt Stratton is a solutions architect..."
++++
+name = "Matt Stratton"
+pronouns = "he/him"
+thumbnail = "img/hosts/matt.png"
+bio = "Matt Stratton is a solutions architect..."
++++
 ```
 
 ## Guests

--- a/docs/creating-episodes-hosts-guests.md
+++ b/docs/creating-episodes-hosts-guests.md
@@ -1,0 +1,69 @@
+# Creating Episodes, Hosts, and Guests
+
+## Episodes
+
+Episodes are stored in `content/episode/`. To create a new episode:
+
+```sh
+hugo new episode/my-episode.md
+```
+
+A typical episode front matter:
+
+```toml
++++
+Description = "Episode description."
+aliases = ["/12"]
+author = "Matt"
+date = "2016-09-25T04:10:01-05:00"
+episode = "12"
+episode_image = "img/episode/default.jpg"
+episode_banner = "img/episode/default-banner.jpg"
+explicit = "no"
+guests = ["jsmith"]
+sponsors = ["bluthcompany"]
+images = ["img/episode/default-social.jpg"]
+podcast_duration = "1:08:22"
+podcast_file = "arrested-devops-podcast-episode053.mp3"
+podcast_bytes = "123456789"
+title = "Back to School"
+youtube = ""
+truncate = ""
+upcoming = false
++++
+```
+
+## Hosts
+
+Hosts are defined in your config under `[params.authors]`:
+
+```toml
+[params.authors]
+  [params.authors.Matt]
+    name = "Matt Stratton"
+    pronouns = "he/him"
+    thumbnail = "img/hosts/matt.png"
+    bio = "Matt Stratton is a solutions architect..."
+```
+
+## Guests
+
+Guests are stored in `content/guest/`. To create a new guest:
+
+```sh
+hugo new guest/jane-smith.md
+```
+
+A typical guest front matter:
+
+```toml
++++
+name = "Jane Smith"
+thumbnail = "img/guests/jane.png"
+bio = "Jane is a DevOps engineer..."
++++
+```
+
+---
+
+For more details, see the [Reference](../REFERENCE.md). 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,52 @@
+# Installation
+
+Castanet is a Hugo theme for podcast websites. To install and use Castanet, follow these steps:
+
+## Prerequisites
+- [Hugo](https://gohugo.io/getting-started/installing/) (version 0.110.0 or later recommended)
+- [Node.js](https://nodejs.org/) and npm (for building assets)
+
+## 1. Add Castanet as a Hugo Module
+
+In your site root, add Castanet as a module:
+
+```toml
+# hugo.toml
+[module]
+  [[module.imports]]
+    path = "github.com/mattstratton/castanet/v2"
+```
+
+## 2. Install Node.js Dependencies
+
+From your site root, run:
+
+```sh
+npm install
+```
+
+## 3. Configure Your Site
+
+See the [Main Configuration](./main-configuration.md) for required and optional settings.
+
+## 4. Build the Site
+
+To build your site:
+
+```sh
+npm run build
+```
+
+The generated site will be in `exampleSite/public`.
+
+## 5. Run Locally
+
+To serve your site locally:
+
+```sh
+hugo server -s exampleSite
+```
+
+---
+
+For more details, see the [Reference](../REFERENCE.md). 

--- a/docs/main-configuration.md
+++ b/docs/main-configuration.md
@@ -1,0 +1,60 @@
+# Main Configuration
+
+Castanet uses a `hugo.toml` file for configuration. Below are the most important settings to get started.
+
+## Top-level Items
+
+- `pagination.pagerSize`: Number of episodes per page (default: 10)
+
+## Build, Module, and Output Settings
+
+```toml
+[build]
+  [build.buildStats]
+    enable = true
+  [[build.cachebusters]]
+    source = 'assets/notwatching/hugo_stats.json'
+    target = 'css'
+  [[build.cachebusters]]
+    source = '(postcss|tailwind).config.js'
+    target = 'css'
+
+[module]
+  [module.hugoVersion]
+  [[module.imports]]
+    path = "github.com/mattstratton/castanet/v2"
+  [[module.mounts]]
+    source = 'assets'
+    target = 'assets'
+  [[module.mounts]]
+    disableWatch = true
+    source = 'hugo_stats.json'
+    target = 'assets/notwatching/hugo_stats.json'
+
+[outputs]
+  home = ["HTML", "RSS", "JSON"]
+  page = ["HTML", "RSS"]
+```
+
+## General Parameters
+
+Set under `[params]`:
+
+- `mainSections` (required): e.g. `"episode"`
+- `colorScheme`: `slate` (default), `violet`, `stone`
+- `site_layout`: `row` (default) or `grid`
+- `description` (required): Show description
+- `media_prefix` (required): URL prefix for podcast files
+- `copyright_notice` (required)
+
+See [REFERENCE.md](../REFERENCE.md) for a full list of parameters and examples.
+
+## Social, Analytics, and More
+
+- Social links: `[params.social]`
+- Analytics: `[params.fathomAnalytics]`, `[params.giscus]`
+- Menus, permalinks, taxonomies, and more are supported.
+
+---
+
+For advanced configuration, see the [Reference](../REFERENCE.md). 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,0 +1,27 @@
+# Migration Guide
+
+This guide helps you migrate your podcast site to Castanet.
+
+## From Previous Castanet Versions
+
+- Review your `hugo.toml` and update to use the new `[module]` and `[params]` structure as shown in the [Main Configuration](./main-configuration.md).
+- Move any custom layouts or assets to the appropriate folders as per Hugo module conventions.
+- Update your episode, host, and guest content to match the latest front matter fields (see [Creating Episodes, Hosts, and Guests](./creating-episodes-hosts-guests.md)).
+- If you used custom taxonomies, menus, or permalinks, review the new recommended settings in [REFERENCE.md](../REFERENCE.md).
+
+## From Other Podcast Themes
+
+- Copy your content (episodes, guests, hosts) into the appropriate `content/` folders.
+- Update front matter fields to match Castanet's expected structure (see [Creating Episodes, Hosts, and Guests](./creating-episodes-hosts-guests.md)).
+- Add and configure `hugo.toml` as described in [Main Configuration](./main-configuration.md).
+- Install Node.js dependencies and run `npm run build` to generate assets.
+
+## General Tips
+
+- Always back up your site before migrating.
+- Test your site locally with `hugo server -s exampleSite`.
+- Refer to [REFERENCE.md](../REFERENCE.md) for detailed field descriptions and examples.
+
+---
+
+If you encounter issues, check the [Castanet GitHub Issues](https://github.com/mattstratton/castanet/issues) or open a new one for help. 


### PR DESCRIPTION
## Summary

This PR introduces a new `docs` folder containing Markdown-based documentation for Castanet, including:
- Installation instructions
- Main configuration guide
- Guide for creating episodes, hosts, and guests
- Migration guide for previous versions and other podcast themes

## Testing Steps
- Review the new files in the `docs` directory for clarity and completeness.
- No code changes; documentation only.

## Context
This change migrates documentation to Markdown files within the repository, replacing the need for Docusaurus or external docs sites. Content is based on the existing REFERENCE.md and project conventions.

---

Fixes # (if applicable)

🤖 This was generated by a bot. If you have questions, please contact the maintainers.