### PR TITLE
Enhancement: Display pronouns as styled tag under name for guests and hosts

### DIFF
--- a/layouts/_partials/list-people.html
+++ b/layouts/_partials/list-people.html
@@ -29,7 +29,7 @@
             {{- end -}}
           </div>
           <div class="w-full md:w-2/3 px-4">
-            <h3 class="text-xl font-semibold mb-2"><a href = "{{ (printf "%s/%s/" $type .File.BaseFileName) | relURL }}">{{ .Title }}</a> {{ with .Params.Pronouns }}({{ . }}){{ end }}</h3>
+            <h3 class="text-xl font-semibold mb-2"><a href = "{{ (printf "%s/%s/" $type .File.BaseFileName) | relURL }}">{{ .Title }}</a> {{ with .Params.Pronouns }}<span class="inline-block px-2 py-0.5 rounded bg-castanet-primary-200 text-xs font-medium text-castanet-primary-800 mt-1">{{ . }}</span>{{ end }}</h3>
             <p class="mb-2">{{ .Content }}</p>
             {{ with .Params.Website }}
               <a href = "{{ . }}" target="_blank"><i class="fas fa-home fa-2x"></i></a>

--- a/layouts/episode/single.html
+++ b/layouts/episode/single.html
@@ -137,7 +137,7 @@
                 {{- end -}}
               </div>
               <div class="w-full md:w-3/4 px-4">
-                <h2 class="text-3xl font-bold mb-4"><a href = "{{(printf "guest/%s/" .File.BaseFileName) | absURL }}">{{ .Title }}</a> {{ with .Params.Pronouns }}({{ . }}){{ end }}</h2>
+                <h2 class="text-3xl font-bold mb-4"><a href = "{{(printf "guest/%s/" .File.BaseFileName) | absURL }}">{{ .Title }}</a> {{ with .Params.Pronouns }}<span class="inline-block px-2 py-0.5 rounded bg-castanet-primary-200 text-xs font-medium text-castanet-primary-800 mt-1">{{ . }}</span>{{ end }}</h2>
                 {{ .Content }}
                 {{- with .Params.Website -}}
                   <a href="{{ . }}" target="_blank">
@@ -231,7 +231,7 @@
                 {{- end -}}
               </div>
               <div class="w-full md:w-3/4 px-4">
-                <h2 class="text-3xl font-bold mb-4"><a href = "{{(printf "host/%s/" .File.BaseFileName) | absURL }}">{{ .Title }}</a> {{ with .Params.Pronouns }}({{ . }}){{ end }}</h2>
+                <h2 class="text-3xl font-bold mb-4"><a href = "{{(printf "host/%s/" .File.BaseFileName) | absURL }}">{{ .Title }}</a> {{ with .Params.Pronouns }}<span class="inline-block px-2 py-0.5 rounded bg-castanet-primary-200 text-xs font-medium text-castanet-primary-800 mt-1">{{ . }}</span>{{ end }}</h2>
                 {{ .Content }}
                 {{- with .Params.Website -}}
                   <a href="{{ . }}" target="_blank">

--- a/layouts/guest/single.html
+++ b/layouts/guest/single.html
@@ -2,7 +2,8 @@
   <div class="max-w-5xl mx-auto py-8 px-4">
     <div class="flex flex-wrap -mx-4 mb-6">
       <div class="w-full px-4">
-        <h1 class="text-3xl font-bold mb-4">{{ title .Title }} {{ with .Params.Pronouns }}({{ . }}){{ end }}</h1>
+        <h1 class="text-3xl font-bold mb-1">{{ title .Title }}</h1>
+        {{ with .Params.Pronouns }}<span class="inline-block px-2 py-0.5 rounded bg-castanet-primary-200 text-xs font-medium text-castanet-primary-800 mt-1">{{ . }}</span>{{ end }}
       </div>
     </div>
     {{ .Scratch.Delete "guest-names" }}

--- a/layouts/host/single.html
+++ b/layouts/host/single.html
@@ -2,7 +2,8 @@
 <div class="max-w-5xl mx-auto py-8 px-4">
   <div class="flex flex-wrap -mx-4 mb-6">
     <div class="w-full px-4">
-      <h1 class="text-3xl font-bold mb-4">{{ title .Title }} {{ with .Params.Pronouns }}({{ . }}){{ end }}</h1>
+      <h1 class="text-3xl font-bold mb-1">{{ title .Title }}</h1>
+      {{ with .Params.Pronouns }}<span class="inline-block px-2 py-0.5 rounded bg-castanet-primary-200 text-xs font-medium text-castanet-primary-800 mt-1">{{ . }}</span>{{ end }}
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- Pronouns for guests and hosts are now displayed as a small, styled tag under the name, rather than in parentheses at the same size as the name.
- This applies to guest and host single pages, episode pages, and list views, using a consistent Tailwind style for clarity and accessibility.

## Testing Steps
- View any guest or host page and confirm pronouns appear as a tag below the name.
- Check episode pages and people lists for the same consistent styling.

## Context
Addresses [#334](https://github.com/mattstratton/castanet/issues/334) for improved visual clarity and a more modern, accessible design.

Fixes #334 

---

🤖 This was generated by a bot. If you have questions, please contact the maintainers.