### PR TITLE
Fix grid and upcoming banner width and spacing to match jumbotron

### DIFF
--- a/exampleSite/hugo_stats.json
+++ b/exampleSite/hugo_stats.json
@@ -206,7 +206,6 @@
       "logo-disqus",
       "max-w-4xl",
       "max-w-5xl",
-      "max-w-6xl",
       "max-w-lg",
       "max-w-none",
       "mb-1",

--- a/layouts/_partials/grid/grid.html
+++ b/layouts/_partials/grid/grid.html
@@ -26,7 +26,8 @@
   {{ end }}
 {{ end }}
 
-<section class="max-w-6xl mx-auto mb-6">
+<div class="w-full max-w-5xl mx-auto px-4">
+<section class="mb-6">
   {{ if or (eq $path "/") (eq $path "/blog") }}
     <div class="w-full px-4 mb-4 bg-castanet-primary-50 p-4 rounded-lg shadow">
       {{ if eq $path "/" }}

--- a/layouts/_partials/grid/grid.html
+++ b/layouts/_partials/grid/grid.html
@@ -14,8 +14,8 @@
 
 {{ if eq $path "/" }}
   {{ if and (and (isset .Site.Params "show_next_upcoming") (eq .Site.Params.show_next_upcoming "true")) (ge (len (where ( where site.RegularPages "Type" "in" site.Params.mainSections) ".Params.upcoming" "==" true )) 1) }}
-  <div class="w-full bg-castanet-primary-50 p-4 mb-6 rounded-lg shadow">
-    <div class="w-full max-w-5xl mx-auto px-4">
+  <div class="w-full max-w-5xl mx-auto px-4 mt-6">
+    <div class="w-full bg-castanet-primary-50 p-4 mb-6 rounded-lg shadow">
       {{ range first 1 (where ( where site.RegularPages "Type" "in" site.Params.mainSections).ByDate ".Params.upcoming" "==" true ) }}
       <p class="text-blue-800">
         Next Episode: <a href="{{ .Permalink }}" class="text-blue-600 hover:text-blue-800 font-medium">{{ .Title }}</a> - Scheduled for {{ dateFormat "Jan 2, 2006" .Date }}


### PR DESCRIPTION
## Summary

This PR fixes layout inconsistencies on the homepage:
- The "Next Episode" (upcoming banner) and the grid container are now visually aligned and have the same width as the jumbotron.
- Added spacing between the jumbotron and the upcoming banner for better visual separation.
- Ensured all three sections use consistent container classes for a unified look.

## Testing Steps
1. Run `npm run build` and view the homepage in `exampleSite/public`.
2. Confirm that the jumbotron, upcoming banner, and grid container are all the same width and visually aligned.
3. Confirm there is appropriate spacing between the jumbotron and the upcoming banner.

## Context
- Addresses visual bugs where the grid and banner were wider or misaligned compared to the jumbotron.

---

🤖 This was generated by a bot. If you have questions, please contact the maintainers.