### PR TITLE
updates to README to get it to build and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ First, initialize [Hugo modules](https://gohugo.io/hugo-modules/) in your repo. 
 hugo mod init github.com/<your username>/<your repo name>
 ```
 
-##### 2. Add this theme as your module dependency
+##### 2. Add this theme as a module dependency
 
 In your `hugo.toml` file, add a `module` section. (exampleSite uses `config/_default/module.toml`)
 
@@ -37,7 +37,7 @@ In your `hugo.toml` file, add a `module` section. (exampleSite uses `config/_def
     target = 'assets/notwatching/hugo_stats.json'
 ```
 
-##### 3. Update config.toml
+##### 3. Add build step
 
 In your `hugo.toml` file, add the following lines: (exampleSite uses `config/_default/build.toml`)
 
@@ -53,10 +53,13 @@ In your `hugo.toml` file, add the following lines: (exampleSite uses `config/_de
     target = 'css'
 ```
 
-Also add the following line to your `hugo.toml` file:
+##### 3. Add required parameters
 
-```toml
-theme = "castanet"
+Also add the following lines to your `hugo.toml` file:
+
+```
+[params]
+  [params.authors]
 ```
 
 ##### 4. Update your module
@@ -82,6 +85,7 @@ hugo mod npm pack
 ##### 2. Install dependencies
 
 Install the node dependencies using following command:
+
 ```bash
 npm install
 ```
@@ -96,7 +100,6 @@ hugo server -w
 
 ## Development
 
-
 ## Theme Features
 
 Castanet is a Hugo theme for sites that are primarily podcasts. It is heavily influenced by [ado-hugo](//github.com/arresteddevops/ado-hugo) by [Matt Stratton](//github.com/mattstratton).
@@ -109,9 +112,7 @@ An example site can be found at https://sample-castanet.netlify.com/
 
 Download the latest version (zip file, not source code) from the [Releases](https://github.com/mattstratton/castanet/releases) page.
 
-
 For more information read the official [quick start](//gohugo.io/getting-started/quick-start/) of Hugo.
-
 
 ## Getting started
 
@@ -120,10 +121,13 @@ After installing Castanet successfully it requires a just a few more steps to ge
 See [REFERENCE.md](https://github.com/mattstratton/castanet/blob/main/REFERENCE.md) for all configuration file settings as well as instructions on episodes, guests, hosts, and sponsors
 
 ## Contributing to castanet
+
 If you would like to help make improvements or fixes to this theme, please see [CONTRIBUTING.md](https://github.com/mattstratton/castanet/blob/master/CONTRIBUTING.md) for detailed instructions.
 
 ## Sites using the Castanet theme
+
 This is a completely non-comprehensive list of podcasts that use this theme. Want to add your site? Submit a pull request against the README file!
+
 - [Arrested DevOps](https://www.arresteddevops.com)
 - [Page It to the Limit](https://www.pageittothelimit.com/)
 - [Quiche-Anon](https://quiche-anon.com)
@@ -132,6 +136,7 @@ This is a completely non-comprehensive list of podcasts that use this theme. Wan
 - [The R-Podcast](https://r-podcast.org)
 
 ## Sites inspired by / building upon the Castanet theme
+
 - [Cloud with Chris](https://www.cloudwithchris.com)
 
 test

--- a/README.md
+++ b/README.md
@@ -53,16 +53,22 @@ In your `hugo.toml` file, add the following lines: (exampleSite uses `config/_de
     target = 'css'
 ```
 
-##### 3. Add required parameters
+##### 4. Add required parameters
 
 Also add the following lines to your `hugo.toml` file:
 
 ```
 [params]
   [params.authors]
+    [params.authors.johndoe]
+      name = "John Doe"
+    [params.authors.janesmith]
+      name = "Jane Smith"
 ```
 
-##### 4. Update your module
+See the example site for more information on supported parameters.
+
+##### 5. Update your module
 
 Now, run this command to load this theme as your module.
 


### PR DESCRIPTION
### **User description**
some basic formatting/updates I had to do to get it building

I don't think `theme = "castanet"` as that comes from the module now, but I may be wrong.

The template seems to require the authors section.


___

### **PR Type**
Documentation


___

### **Description**
- Fix README build instructions and formatting

- Update theme configuration from deprecated syntax

- Add required parameters section for authors

- Clean up markdown formatting and spacing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old README"] --> B["Fix Instructions"]
  B --> C["Update Config"]
  C --> D["Clean Formatting"]
  D --> E["Working Build"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix build instructions and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated installation instructions with correct theme configuration<br> <li> Removed deprecated <code>theme = "castanet"</code> line<br> <li> Added required <code>[params.authors]</code> section<br> <li> Fixed markdown formatting and spacing issues</ul>


</details>


  </td>
  <td><a href="https://github.com/mattstratton/castanet/pull/517/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+13/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

