### PR TITLE
Fix Hugo 0.144/0.158 deprecation breakages in RSS templates

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,9 +13,9 @@ buildFuture = true
   tag = "tags"
 
 [permalinks]
-	# page = "/:filename/"
-	about = "/:filename/"
-	episode = "/:filename/"
+	# page = "/:contentbasename/"
+	about = "/:contentbasename/"
+	episode = "/:contentbasename/"
 
 
 # The theme supports menus with up to one submenu per menu item
@@ -101,6 +101,10 @@ disqusShortname = ""
   # If you want to use fathom(https://usefathom.com) for analytics, add this section
   [params.fathomAnalytics]
     siteID = "ABCDE"
+
+  [params.author]
+    name = "Matt Stratton"
+    email = "matt.stratton@gmail.com"
 
   [params.feed]
     copyright = "Copyright 2020 Matt Stratton" #do not use markdown in this field; it is used in the feed

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html itemscope lang="{{ .Site.LanguageCode }}">
+<html itemscope lang="{{ .Site.Language.Locale }}">
 <head>
 {{ partial "head.html" . }}
 </head>

--- a/layouts/_default/blog.rss.xml
+++ b/layouts/_default/blog.rss.xml
@@ -3,10 +3,10 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink  }}</link>
     <description>Recent blogs {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
@@ -15,7 +15,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | htmlEscape }}</description>
     </item>

--- a/layouts/_default/episode.rss.xml
+++ b/layouts/_default/episode.rss.xml
@@ -17,7 +17,7 @@
     <lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" .Date }}</lastBuildDate>
     <sy:updatePeriod>hourly</sy:updatePeriod>
     <sy:updateFrequency>1</sy:updateFrequency>
-    <language>{{ .Site.Params.feed.language | default .Site.LanguageCode }}</language>
+    <language>{{ .Site.Params.feed.language | default .Site.Language.Locale }}</language>
     <copyright>{{ .Site.Params.feed.copyright }}</copyright>
     {{ with .Site.Params.feed.itunes_subtitle }}<itunes:subtitle>{{ . }}</itunes:subtitle>{{ end }}
     <itunes:author>{{ .Site.Params.feed.itunes_author }}</itunes:author>

--- a/layouts/blog/section.rss.xml
+++ b/layouts/blog/section.rss.xml
@@ -3,10 +3,10 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink  }}</link>
     <description>Recent blogs {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
@@ -15,7 +15,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | htmlEscape }}</description>
     </item>

--- a/layouts/episode/section.rss.xml
+++ b/layouts/episode/section.rss.xml
@@ -17,7 +17,7 @@
     <lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" .Date }}</lastBuildDate>
     <sy:updatePeriod>hourly</sy:updatePeriod>
     <sy:updateFrequency>1</sy:updateFrequency>
-    <language>{{ .Site.Params.feed.language | default .Site.LanguageCode }}</language>
+    <language>{{ .Site.Params.feed.language | default .Site.Language.Locale }}</language>
     <copyright>{{ .Site.Params.feed.copyright }}</copyright>
     {{ with .Site.Params.feed.itunes_subtitle }}<itunes:subtitle>{{ . }}</itunes:subtitle>{{ end }}
     <itunes:author>{{ .Site.Params.feed.itunes_author }}</itunes:author>

--- a/layouts/section/blog.rss.xml
+++ b/layouts/section/blog.rss.xml
@@ -3,10 +3,10 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink  }}</link>
     <description>Recent blogs {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
@@ -15,7 +15,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | htmlEscape }}</description>
     </item>

--- a/layouts/section/episode.rss.xml
+++ b/layouts/section/episode.rss.xml
@@ -17,7 +17,7 @@
     <lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" .Date }}</lastBuildDate>
     <sy:updatePeriod>hourly</sy:updatePeriod>
     <sy:updateFrequency>1</sy:updateFrequency>
-    <language>{{ .Site.Params.feed.language | default .Site.LanguageCode }}</language>
+    <language>{{ .Site.Params.feed.language | default .Site.Language.Locale }}</language>
     <copyright>{{ .Site.Params.feed.copyright }}</copyright>
     {{ with .Site.Params.feed.itunes_subtitle }}<itunes:subtitle>{{ . }}</itunes:subtitle>{{ end }}
     <itunes:author>{{ .Site.Params.feed.itunes_author }}</itunes:author>


### PR DESCRIPTION
Fixes #518.

## Summary

- Building a Castanet site with Hugo >= 0.158 errors out because `.Site.Author` was removed and the `:filename` permalink token was removed in 0.144.
- Replaces `.Site.Author.{email,name}` with `.Site.Params.author.{email,name}` in the three blog-section RSS templates, so authors are now sourced from a `[params.author]` config block.
- Swaps `.Site.LanguageCode` for `.Site.Language.Locale` in the affected RSS templates and `_default/baseof.html`.
- Updates `exampleSite/config.toml` to use the `:contentbasename` permalink token and adds a sample `[params.author]` block to document the new config surface.

Two non-fatal deprecation warnings remain after this change and are intentionally left out of scope:

- top-level `languageCode` config key (Hugo wants the language defined under `[languages.<lang>]`)
- `.Site.Data` access in `layouts/episode/single.html` (Hugo wants `hugo.Data`)

## Test plan

- [x] `hugo` against `exampleSite/` with `hugo extended v0.161.1` — completes without errors (was previously broken)
- [x] `hugo` against a real production site (softwareinblue.com) — completes without errors
- [ ] Maintainer to verify on their own setup